### PR TITLE
Fix production webpack

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -13,7 +13,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.tsx?$/,
+        test: /\.ts?/,
         use: ['babel-loader', 'eslint-loader'],
         exclude: /node_modules/,
       },

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -4,4 +4,15 @@ module.exports = {
   mode: 'production',
   ...webpackBaseConfig,
   devtool: false,
+  externals: {
+    '@axe-core/react': 'devtools',
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
+  performance: {
+    hints: 'error',
+  },
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test": "yarn test:ts"
   },
   "dependencies": {
-    "@axe-core/react": "^4.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
@@ -32,6 +31,7 @@
     "styled-normalize": "^8.0.7"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.1.1",
     "@babel/core": "^7.13.8",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/preset-env": "^7.13.8",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,8 +6,6 @@ import { App } from 'App'
 import { GlobalStyle } from 'styles/GlobalStyle'
 import { Environment } from 'utils/environment'
 
-import axe from '@axe-core/react'
-
 const renderApp = () =>
   render(
     <BrowserRouter>
@@ -18,7 +16,7 @@ const renderApp = () =>
   )
 
 if (Environment.mode === 'development') {
-  axe(React, ReactDOM, 1000)
+  import('@axe-core/react').then((axe) => axe.default(React, ReactDOM, 1000))
 }
 
 renderApp()


### PR DESCRIPTION
This PR addresses the issue of an overly large production build. Dev only tools used within the source must be excluded from the output.

**Commits:**

- Properly import axe-core
- Adjust webpack configs to prevent large module exports