### PR TITLE
Add production compression

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -1,3 +1,5 @@
+const CompressionPlugin = require('compression-webpack-plugin')
+
 const webpackBaseConfig = require('./webpack.base.config')
 
 module.exports = {
@@ -17,4 +19,5 @@ module.exports = {
     hints: 'error',
     maxEntrypointSize: 300000,
   },
+  plugins: [...webpackBaseConfig.plugins, new CompressionPlugin()],
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "compression-webpack-plugin": "^7.1.2",
     "eslint": "^7.21.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4195,6 +4195,14 @@ compressible@~2.0.16:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
+compression-webpack-plugin@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-7.1.2.tgz#f9a1ba84d4879693e29726f6884b382940876597"
+  integrity sha512-9DKNW6ILLjx+bNBoviHDgLx6swBhWWH9ApClC9sTH2NoFfQM47BapQfovCm9zjD9v1uZwInF5a925FB9ErGQeQ==
+  dependencies:
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+
 compression@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"


### PR DESCRIPTION
This PR adds a compression plugin that produces gzip versions of the web assets on production builds

**Commits:**

- Add webpack compression plugin
- Create compressed versions of output files for production build