### PR TITLE
Page template

### DIFF
--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Colors } from 'styles/Colors'
+import { Colors } from 'styles'
 import { messages } from 'translations'
 import { Heading as HeadingComponent } from './index'
 

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes } from 'react'
 import { useIntl } from 'react-intl'
 import styled from 'styled-components'
 
-import { Color, Colors } from 'styles/Colors'
+import { Color, Colors } from 'styles'
 import { MessageValues } from 'utils/internationalization'
 
 interface Props extends HTMLAttributes<HTMLHeadingElement> {

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -31,6 +31,7 @@ const HeadingElement = ({ level = 2, messageId, messageValues, ...rest }: Props)
   }
 }
 
-export const Heading = styled(HeadingElement)<Props>`
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const Heading = styled(({ color, ...rest }: Props) => <HeadingElement {...rest} />)<Props>`
   ${(props) => (props.color ? `color: ${Colors[props.color]};` : '')};
 `

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+import { Colors } from 'styles'
+import { messages } from 'translations'
+import { Link as LinkComponent } from './index'
+
+export default {
+  title: 'Design System/Components/Link',
+  argTypes: {
+    color: {
+      control: {
+        type: 'select',
+        options: [...Object.keys(Colors)],
+      },
+    },
+    hoverColor: {
+      control: {
+        type: 'select',
+        options: [...Object.keys(Colors)],
+      },
+    },
+    messageId: {
+      control: {
+        type: 'select',
+        options: [...Object.keys(messages.en)],
+      },
+    },
+    messageValues: {
+      control: {
+        type: 'object',
+      },
+    },
+    size: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+}
+
+type Props = Parameters<typeof LinkComponent>[0]
+export const Link = (props: Props) => <LinkComponent {...props} />
+Link.args = {
+  bold: false,
+  color: undefined,
+  hoverColor: undefined,
+  italic: false,
+  messageId: 'lorem-ipsum.sentence-01',
+  messageValues: undefined,
+  nounderline: false,
+  size: undefined,
+}

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,0 +1,26 @@
+import { axe, toHaveNoViolations } from 'jest-axe'
+import React from 'react'
+
+import { render } from 'devtools/testing-library'
+import { messages } from 'translations'
+import { Link } from './index'
+
+expect.extend(toHaveNoViolations)
+
+describe('Link', () => {
+  const messageId = 'lorem-ipsum.sentence-01'
+
+  it('renders without error', () => {
+    const { getByText } = render(<Link {...{ messageId }} to="#null" />)
+    const renderedText = getByText(messages.en[messageId])
+
+    expect(renderedText).toBeDefined()
+  })
+
+  it('adheres to accessibility standards', async () => {
+    const { container } = render(<Link {...{ messageId }} to="#null" />)
+    const results = await axe(container)
+
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode } from 'react'
+import { useIntl } from 'react-intl'
+import { Link as ReactRouterLink, LinkProps as ReactRouterLinkProps } from 'react-router-dom'
+import styled from 'styled-components'
+
+import { Color, Colors } from 'styles'
+import { MessageValues } from 'utils/internationalization'
+
+interface Props extends Omit<ReactRouterLinkProps, 'children'> {
+  bold?: boolean
+  color?: Color
+  hoverColor?: Color
+  italic?: boolean
+  messageId: string
+  messageValues?: MessageValues
+  nounderline?: boolean
+  size?: number
+}
+
+type StyledProps = Omit<Props, 'messageId' | 'messageValues'> & { children: ReactNode }
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const StyledLink = styled(({ bold, children, color, hoverColor, italic, nounderline, size, ...rest }: StyledProps) => (
+  <ReactRouterLink {...rest}>{children}</ReactRouterLink>
+))<StyledProps>`
+  font-size: ${(props) => (props.size ? props.size : '1')}em;
+  ${(props) => (props.bold ? 'font-weight: 600;' : '')}
+  ${(props) => (props.italic ? 'font-style: italic;' : '')}
+  ${(props) => (props.nounderline ? 'text-decoration: none;' : '')}
+  color: ${(props) => (props.color ? Colors[props.color] : Colors.DEEP_SPACE_SPARKLE)};
+
+  &:visited, &:link {
+    color: ${(props) => (props.color ? Colors[props.color] : Colors.DEEP_SPACE_SPARKLE)};
+  }
+
+  &:active, &:hover {
+    color: ${(props) => (props.hoverColor ? Colors[props.hoverColor] : Colors.ALLOY_ORANGE)};
+  }
+`
+
+export const Link = ({ messageId, messageValues, ...rest }: Props) => {
+  const { formatMessage } = useIntl()
+  return <StyledLink {...rest}>{formatMessage({ id: messageId }, messageValues)}</StyledLink>
+}

--- a/src/components/NavigationBanner/NavigationBanner.test.tsx
+++ b/src/components/NavigationBanner/NavigationBanner.test.tsx
@@ -1,0 +1,27 @@
+import { axe, toHaveNoViolations } from 'jest-axe'
+import React from 'react'
+
+import { render } from 'devtools/testing-library'
+import { messages } from 'translations'
+import { NavigationBanner } from './index'
+
+expect.extend(toHaveNoViolations)
+
+describe('NavigationBanner', () => {
+  it('renders without error', () => {
+    const { getByText } = render(<NavigationBanner />)
+
+    const siteName = getByText(messages.en['site.name'])
+    expect(siteName).toBeDefined()
+
+    const headingContact = getByText(messages.en['heading.contact'])
+    expect(headingContact).toBeDefined()
+  })
+
+  it('adheres to accessibility standards', async () => {
+    const { container } = render(<NavigationBanner />)
+    const results = await axe(container)
+
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/src/components/NavigationBanner/index.tsx
+++ b/src/components/NavigationBanner/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Link } from 'components'
+import { Routes } from 'config/routes'
+import { Breakpoints, Colors } from 'styles'
+
+const Wrapper = styled.nav`
+  display: block;
+  background-color: ${Colors.IVORY};
+  position: relative;
+  top: 16px;
+  height: 80px;
+  width: 100%;
+`
+
+const Content = styled.div`
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  max-width: 1020px;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  justify-content: space-between;
+
+  @media ${Breakpoints.Mobile} {
+    margin-left: 20px;
+    margin-right: 20px;
+  }
+`
+
+export const NavigationBanner = () => (
+  <Wrapper>
+    <Content>
+      <div>
+        <Link
+          messageId="site.name"
+          size={1.3}
+          to={Routes.Contact}
+          color="JET"
+          hoverColor="DAVYS_GREY"
+          nounderline
+          bold
+        />
+      </div>
+      <div>
+        <Link
+          messageId="heading.contact"
+          size={1.3}
+          to={Routes.Contact}
+          color="JET"
+          hoverColor="DAVYS_GREY"
+          nounderline
+          bold
+        />
+      </div>
+    </Content>
+  </Wrapper>
+)

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Colors } from 'styles/Colors'
+import { Colors } from 'styles'
 import { messages } from 'translations'
 import { Text as TextComponent } from './index'
 

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useIntl } from 'react-intl'
 import styled from 'styled-components'
 
-import { Color, Colors } from 'styles/Colors'
+import { Color, Colors } from 'styles'
 import { MessageValues } from 'utils/internationalization'
 
 interface Props {

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import { useIntl } from 'react-intl'
 import styled from 'styled-components'
 
@@ -12,18 +12,23 @@ interface Props {
   messageId: string
   messageValues?: MessageValues
   size?: number
+  underline?: boolean
 }
 
-type StyledProps = Omit<Props, 'messageId' | 'messageValues'>
+type StyledProps = Omit<Props, 'messageId' | 'messageValues'> & { children: ReactNode }
 
-const StyledText = styled.span<StyledProps>`
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const StyledText = styled(({ bold, children, color, italic, size, underline, ...rest }: StyledProps) => (
+  <span {...rest}>{children}</span>
+))<StyledProps>`
   font-size: ${(props) => (props.size ? props.size : '1')}em;
   ${(props) => (props.bold ? 'font-weight: 600;' : '')}
   ${(props) => (props.italic ? 'font-style: italic;' : '')}
+  ${(props) => (props.underline ? 'text-decoration: underline;' : '')}
   ${(props) => (props.color ? `color: ${Colors[props.color]};` : '')}
 `
 
-export const Text = ({ bold, color, italic, messageId, messageValues, size }: Props) => {
+export const Text = ({ messageId, messageValues, ...rest }: Props) => {
   const { formatMessage } = useIntl()
-  return <StyledText {...{ bold, color, italic, size }}>{formatMessage({ id: messageId }, messageValues)}</StyledText>
+  return <StyledText {...rest}>{formatMessage({ id: messageId }, messageValues)}</StyledText>
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { Heading } from 'components/Heading'
+export { Link } from 'components/Link'
 export { Text } from 'components/Text'
 export { Title } from 'components/Title'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,3 @@
+export { Heading } from 'components/Heading'
+export { Text } from 'components/Text'
+export { Title } from 'components/Title'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { Heading } from 'components/Heading'
 export { Link } from 'components/Link'
+export { NavigationBanner } from 'components/NavigationBanner'
 export { Text } from 'components/Text'
 export { Title } from 'components/Title'

--- a/src/pages/Contact/index.tsx
+++ b/src/pages/Contact/index.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 
-import { Heading } from 'components/Heading'
-import { Text } from 'components/Text'
-import { Title } from 'components/Title'
+import { Heading, Text, Title } from 'components'
 
 export const Contact = () => (
   <main>

--- a/src/pages/Contact/index.tsx
+++ b/src/pages/Contact/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 
-import { Heading, Text, Title } from 'components'
+import { Text } from 'components'
+import { PageTemplate } from 'templates/PageTemplate'
 
 export const Contact = () => (
-  <main>
-    <Title messageId="heading.contact" />
-    <Heading messageId="heading.contact" level={1} />
+  <PageTemplate titleId="heading.contact" colorBand="ALLOY_ORANGE">
     <Text messageId="lorem-ipsum.sentence-01" />
-  </main>
+  </PageTemplate>
 )

--- a/src/styles/Breakpoints.ts
+++ b/src/styles/Breakpoints.ts
@@ -1,0 +1,3 @@
+export const Breakpoints = {
+  Mobile: 'only screen and (max-width: 767px)',
+}

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -1,5 +1,6 @@
 export const Colors = {
   ALLOY_ORANGE: '#bd632f',
+  DAVYS_GREY: '#5e5e5e',
   DEEP_SPACE_SPARKLE: '#3a5c69',
   HARVEST_GOLD: '#d8973c',
   IVORY: '#fffff0',

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -1,7 +1,7 @@
 import { createGlobalStyle } from 'styled-components'
 import styledNormalize from 'styled-normalize'
 
-import { Colors } from 'styles/Colors'
+import { Colors } from 'styles'
 
 export const GlobalStyle = createGlobalStyle`
   ${styledNormalize}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,4 +1,5 @@
 import { Color as ColorImport } from 'styles/Colors'
 
 export type Color = ColorImport
+export { Breakpoints } from 'styles/Breakpoints'
 export { Colors } from 'styles/Colors'

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,4 @@
+import { Color as ColorImport } from 'styles/Colors'
+
+export type Color = ColorImport
+export { Colors } from 'styles/Colors'

--- a/src/templates/PageTemplate/ColorBand.tsx
+++ b/src/templates/PageTemplate/ColorBand.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Heading, NavigationBanner } from 'components'
+import { Breakpoints, Color, Colors } from 'styles'
+
+interface Props {
+  colorBand: Color
+  titleId: string
+}
+
+type WrapperProps = Pick<Props, 'colorBand'>
+
+const Wrapper = styled.header<WrapperProps>`
+  display: block;
+  background-color: ${(props) => Colors[props.colorBand]};
+  width: 100%;
+  min-height: 350px;
+
+  @media ${Breakpoints.Mobile} {
+    min-height: auto;
+  }
+`
+
+const Content = styled.div`
+  max-width: 1020px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 80px 40px 40px 40px;
+
+  @media ${Breakpoints.Mobile} {
+    padding: 20px 20px 5px 20px;
+  }
+`
+
+export const ColorBand = ({ colorBand, titleId }: Props) => (
+  <Wrapper {...{ colorBand }}>
+    <NavigationBanner />
+    <Content>
+      <Heading level={1} color="IVORY" messageId={titleId} />
+    </Content>
+  </Wrapper>
+)

--- a/src/templates/PageTemplate/index.tsx
+++ b/src/templates/PageTemplate/index.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode } from 'react'
+import styled from 'styled-components'
+
+import { Title } from 'components'
+import { Breakpoints, Color } from 'styles'
+import { ColorBand } from './ColorBand'
+
+interface Props {
+  children: ReactNode
+  colorBand: Color
+  titleId: string
+}
+
+const Main = styled.main`
+  display: block;
+  width: 100%;
+`
+
+const Content = styled.div`
+  max-width: 1020px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 40px;
+
+  @media ${Breakpoints.Mobile} {
+    padding: 20px;
+  }
+`
+
+export const PageTemplate = ({ children, colorBand, titleId }: Props) => (
+  <>
+    <Title messageId={titleId} />
+    <ColorBand {...{ colorBand, titleId }} />
+    <Main>
+      <Content>{children}</Content>
+    </Main>
+  </>
+)


### PR DESCRIPTION
This PR adds the concept of a page template that will be used in each of the pages. For the moment, templates will not be added to storybook. In addition, some issues with base components were corrected preventing React styling props from being passed to the underlying rendered HTML components. Finally, some of the imports have been simplified.