### PR TITLE
Update ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,9 @@
       "@typescript-eslint/explicit-function-return-type": 1,
       "@typescript-eslint/explicit-module-boundary-types": 1,
       "@typescript-eslint/no-explicit-any": 0,
+      "@typescript-eslint/no-unused-vars": ["error", {
+        "ignoreRestSiblings": true
+      }],
       "@typescript-eslint/no-use-before-define": 1,
       "block-scoped-var": 1,
       "comma-dangle": 0,
@@ -59,6 +62,7 @@
         }
       ],
       "no-console": 0,
+      "no-unused-vars": 0,
       "no-use-before-define": 0,
       "object-curly-newline": 0,
       "react/jsx-filename-extension": [

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -31,7 +31,6 @@ const HeadingElement = ({ level = 2, messageId, messageValues, ...rest }: Props)
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const Heading = styled(({ color, ...rest }: Props) => <HeadingElement {...rest} />)<Props>`
   ${(props) => (props.color ? `color: ${Colors[props.color]};` : '')};
 `

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -19,7 +19,6 @@ interface Props extends Omit<ReactRouterLinkProps, 'children'> {
 
 type StyledProps = Omit<Props, 'messageId' | 'messageValues'> & { children: ReactNode }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const StyledLink = styled(({ bold, children, color, hoverColor, italic, nounderline, size, ...rest }: StyledProps) => (
   <ReactRouterLink {...rest}>{children}</ReactRouterLink>
 ))<StyledProps>`

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -17,7 +17,6 @@ interface Props {
 
 type StyledProps = Omit<Props, 'messageId' | 'messageValues'> & { children: ReactNode }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const StyledText = styled(({ bold, children, color, italic, size, underline, ...rest }: StyledProps) => (
   <span {...rest}>{children}</span>
 ))<StyledProps>`


### PR DESCRIPTION
This PR modifies the ESLint rules to prevent the need of ignoring rules when ignoring variables that are ...rest siblings. Ignoring rest sibling properties are useful for Styled-components as we don't want to pass properties that are consumed by the CSS template literal block as invalid attributes to the underlying HTML components.