### PR TITLE
Do not run code review on pushes outside of PRs

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -1,5 +1,10 @@
 name: Automated Code Review
-on: [push]
+on:
+  push:
+    branches:
+      - '*'
+      - '*/*'
+      - '!master'
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR prevents unwanted tests during automated pushes. Code review actions should only be applied to commits that are part of PRs.